### PR TITLE
Add HTML output as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This will start the server on `localhost:5000`.
 
 ### /\<table\>
 
-When provided with a table name (which must exist in the database), sending a GET request to this path will return the first 100 results from that table in TSV format.
+When provided with a table name (which must exist in the database), sending a GET request to this path will return the first 100 results from that table. By default, this is an HTML page, but you can choose to get a `tsv` or `csv` table using the `format` parameter below.
 
 Optional query parameters:
-* `format`: Export the results in given format, must be either `tsv` (default) or `csv`
+* `format`: Export the results in given format, must be `html` (default), `tsv`, or `csv`
 * `limit`: Return a different number of results, must be an integer
 * `offset`: Return results starting after given integer (e.g., `offset=5` will return results starting with the 6th result)
 * `order`: See [ORDER BY Clauses](#order-by-clauses)

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(
     install_requires=install_requires,
     packages=find_packages(exclude="tests"),
     entry_points={"console_scripts": ["sprocket=sprocket.run:main"]},
+    package_data={"sprocket": ["resources/*.html"]}
 )

--- a/sprocket/resources/template.html
+++ b/sprocket/resources/template.html
@@ -16,23 +16,50 @@
 					</button>
 				</h2>
 				<div id="collapseOptions" class="accordion-collapse collapse show" data-bs-parent="#accordionOptions">
-					<div class="accordion-body" style="padding-bottom:110px;">
+					<div class="accordion-body">
 						<form method="get">
-							<div class="row g-3 float-end">
-								<div class="col-auto">
+							<div class="row g-3">
+								<div class="col-md-6" style="padding-right:30px;">
+									{% for h in headers %}
 									<div class="row">
-										<div style="height:100px; width:200px; border: 1px solid #ced4da; border-radius: .25rem; overflow: auto;">
-											{% for s in select %}
-											<div class="form-check">
-												{% if s in headers %}
-												<input class="form-check-input" type="checkbox" name="select[]" id="{{ s }}" value="{{ s }}" checked>
-												{% else %}
-												<input class="form-check-input" type="checkbox" name="select[]" id="{{ s }}" value="{{ s }}">
-												{% endif %}
-												<label class="form-check-label" for="{{ s }}">{{ s }}</label>
-											</div>
-											{% endfor %}
+										<div class="col-sm-2 col-form-label">
+											<label>{{ h }}</label>
 										</div>
+										<div class="col-sm-4">
+											<select class="form-select" id="{{ h }}Operator" name="operator">
+												<option selected></option>
+												<option value="eq">equals</option>
+												<option value="gt">greater than</option>
+												<option value="gte">greater than or equals</option>
+												<option value="lt">less than</option>
+												<option value="lte">less than or equals</option>
+												<option value="neq">not equals</option>
+												<option value="like">like</option>
+												<option value="ilike">like (insensitive)</option>
+												<option value="is">is</option>
+												<option value="not.is">is not</option>
+												<option value="in">in</option>
+												<option value="not.in">not in</option>
+											</select>
+										</div>
+										<div class="col-sm-6">
+											<input class="form-control" id="{{ h }}Constraint" name="constraint" type="text">
+										</div>
+									</div>
+									{% endfor %}
+								</div>
+								<div class="col-md-2">
+									<div class="row">
+										{% for s in select %}
+										<div class="form-check">
+											{% if s in headers %}
+											<input class="form-check-input" type="checkbox" name="select[]" id="{{ s }}" value="{{ s }}" checked>
+											{% else %}
+											<input class="form-check-input" type="checkbox" name="select[]" id="{{ s }}" value="{{ s }}">
+											{% endif %}
+											<label class="form-check-label" for="{{ s }}">{{ s }}</label>
+										</div>
+										{% endfor %}
 									</div>
 									<input type="hidden" id="select" name="select" value="">
 								</div>
@@ -48,6 +75,9 @@
 										</div>
 									</div>
 									<div class="row float-end" style="padding-top:20px;">
+										<div class="col-auto">
+											<a class="btn btn-secondary" href="javascript:reset()">Reset</a>
+										</div>
 										<div class="col-auto">
 											<input type="button" onclick="submitForm();" class="btn btn-primary" value="Update">
 										</div>
@@ -112,6 +142,17 @@
 	</div>
 
 	<script>
+		// Init headers
+		var headers = [];
+		{% for h in headers %}
+		headers.push('{{ h }}');
+		{% endfor %}
+
+		function reset() {
+			var url = window.location.href.split('?')[0];
+			window.location.href = url;
+		}
+
 		function sort(col, desc) {
 			// Get current parameters
 			var qString = window.location.search;
@@ -145,6 +186,15 @@
 
 		function submitForm() {
 			var args = []
+			// Get the where options
+			for (var h of headers) {
+				var operator = document.getElementById(h + 'Operator').value;
+				var constraint = document.getElementById(h + 'Constraint').value;
+				if (operator && constraint) {
+					args.push(h + "=" + operator + "." + constraint);
+				}
+			}
+
 			// Get the select options
 			var n = document.getElementsByName('select[]');
 			var s = [];

--- a/sprocket/resources/template.html
+++ b/sprocket/resources/template.html
@@ -20,35 +20,38 @@
 						<form method="get">
 							<div class="row g-3">
 								<div class="col-md-6" style="padding-right:30px;">
-									{% for h in headers %}
+									<p class="lead">Filter results</p>
+									{% for h, details in headers.items() %}
 									<div class="row">
 										<div class="col-sm-2 col-form-label">
 											<label>{{ h }}</label>
 										</div>
 										<div class="col-sm-4">
 											<select class="form-select" id="{{ h }}Operator" name="operator">
+												{% if not details.has_selected %}
 												<option selected></option>
-												<option value="eq">equals</option>
-												<option value="gt">greater than</option>
-												<option value="gte">greater than or equals</option>
-												<option value="lt">less than</option>
-												<option value="lte">less than or equals</option>
-												<option value="neq">not equals</option>
-												<option value="like">like</option>
-												<option value="ilike">like (insensitive)</option>
-												<option value="is">is</option>
-												<option value="not.is">is not</option>
-												<option value="in">in</option>
-												<option value="not.in">not in</option>
+												{% endif %}
+												{% for val, optdetails in details.options.items() %}
+													{% if optdetails.selected %}
+													<option value="{{ val }}" selected>{{ optdetails.label }}</option>
+													{% else %}
+													<option value="{{ val }}">{{ optdetails.label }}</option>
+													{% endif %}
+												{% endfor %}
 											</select>
 										</div>
 										<div class="col-sm-6">
+											{% if details.const %}
+											<input class="form-control" id="{{ h }}Constraint" name="constraint" type="text" value="{{ details.const }}">
+											{% else %}
 											<input class="form-control" id="{{ h }}Constraint" name="constraint" type="text">
+											{% endif %}
 										</div>
 									</div>
 									{% endfor %}
 								</div>
 								<div class="col-md-2">
+									<p class="lead">Show columns</p>
 									<div class="row">
 										{% for s in select %}
 										<div class="form-check">
@@ -138,6 +141,11 @@
 				{% endif %}
 				<a href="{{ next_url }}">Next</a>
 			</div>
+		</div>
+	</div>
+	<div class="row" style="padding-left:10px; padding-right:10px;">
+		<div class="col">
+			<p>Download results: <a href="{{ this_url }}&format=tsv">tsv</a> | <a href="{{ this_url }}&format=csv">csv</a></p>
 		</div>
 	</div>
 

--- a/sprocket/resources/template.html
+++ b/sprocket/resources/template.html
@@ -1,0 +1,171 @@
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css" rel="stylesheet">
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"></script>
+
+</head>
+<body>
+	<div class="row" style="padding:10px;">
+		<div class="accordion" id="accordionOptions">
+			<div class="accordion-item">
+				<h2 class="accordion-header">
+					<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOptions">
+						<strong>Query Options</strong>
+					</button>
+				</h2>
+				<div id="collapseOptions" class="accordion-collapse collapse show" data-bs-parent="#accordionOptions">
+					<div class="accordion-body" style="padding-bottom:110px;">
+						<form method="get">
+							<div class="row g-3 float-end">
+								<div class="col-auto">
+									<div class="row">
+										<div style="height:100px; width:200px; border: 1px solid #ced4da; border-radius: .25rem; overflow: auto;">
+											{% for s in select %}
+											<div class="form-check">
+												{% if s in headers %}
+												<input class="form-check-input" type="checkbox" name="select[]" id="{{ s }}" value="{{ s }}" checked>
+												{% else %}
+												<input class="form-check-input" type="checkbox" name="select[]" id="{{ s }}" value="{{ s }}">
+												{% endif %}
+												<label class="form-check-label" for="{{ s }}">{{ s }}</label>
+											</div>
+											{% endfor %}
+										</div>
+									</div>
+									<input type="hidden" id="select" name="select" value="">
+								</div>
+								<div class="col-auto">
+									<div class="row">
+										<div class="col-auto">
+											<label for="limit" class="col-form-label" style="margin-left:20px;">Results per page</label>
+										</div>
+										<div class="col-auto">
+											<select class="form-select" id="limitValue" name="limit">
+												{{ options|safe }}
+											</select>
+										</div>
+									</div>
+									<div class="row float-end" style="padding-top:20px;">
+										<div class="col-auto">
+											<input type="button" onclick="submitForm();" class="btn btn-primary" value="Update">
+										</div>
+									</div>
+								</div>
+							</div>
+						</form>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<table class="table">
+		<thead>
+			<tr>
+				{% for th in headers %}
+				<th>
+					<div class="row justify-content-between">
+						<div class="col-auto">{{ th }}</div>
+						<div class="col-auto">
+							<div class="dropdown">
+								<button class="btn btn-light dropdown-toggle" type="button" id="{{ th }}Dropdown" data-bs-toggle="dropdown"> </button>
+								<ul class="dropdown-menu">
+									<li><a class="dropdown-item" href="javascript:sort('{{ th }}', false)">Ascending</a></li>
+									<li><a class="dropdown-item" href="javascript:sort('{{ th }}', true)">Descending</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</th>
+				{% endfor %}
+			</tr>
+		</thead>
+		<tbody>
+			{% for row in rows %}
+			<tr>
+				{% for itm in row %}
+				{% if itm %}
+				<td>{{ itm }}</td>
+				{% else %}
+				<td></td>
+				{% endif %}
+				{% endfor %}
+			</tr>
+			{% endfor %}
+		</tbody>
+	</table>
+
+	<div class="row" style="padding-left:10px; padding-right:10px;">
+		<div class="col">
+			<p class="fst-italic">Showing results {{ offset + 1 }}-{{ limit + offset }}</p>
+		</div>
+		<div class="col">
+			<div class="float-end">
+				{% if prev_url %}
+				<a href="{{ prev_url }}">Previous</a>&nbsp;|&nbsp;
+				{% endif %}
+				<a href="{{ next_url }}">Next</a>
+			</div>
+		</div>
+	</div>
+
+	<script>
+		function sort(col, desc) {
+			// Get current parameters
+			var qString = window.location.search;
+			var params = new URLSearchParams(qString);
+			var newParams = [];
+			var newOrder = [];
+			// Add all current params to new params, only add order keys that are not col
+			for (var entry of params.entries()) {
+				if (entry[0] !== "order") {
+					newParams.push(`${entry[0]}=${entry[1]}`);
+				} else {
+					for (var ord of entry[1].split(",")) {
+						if (!ord.startsWith(col + ".") && ord !== col) {
+							newOrder.push(ord);
+						}
+					}				
+				}
+			}
+			// Add this col to the order
+			if (desc) {
+				newOrder.push(col + ".desc");
+			} else {
+				newOrder.push(col);
+			}
+			// Redirect to new URL
+			newParams.push("order=" + newOrder.join(","));
+			if (newParams.length > 0) {
+				window.location.href = "?" + newParams.join("&");
+			}
+		}
+
+		function submitForm() {
+			var args = []
+			// Get the select options
+			var n = document.getElementsByName('select[]');
+			var s = [];
+			for (i=0; i < (n.length); i++) {
+				if (n[i].checked) {
+					s.push(n[i].value);
+				}
+			}
+			if (s.length > 0) {
+				args.push("select=" + s.join(","));
+			}
+
+			// Get the limit option
+			var l = document.getElementById("limitValue").value;
+			args.push("limit=" + l);
+
+			// Redirect to new URL
+			if (args.length > 0) {
+				window.location.href = "?" + args.join("&")
+			}
+		}
+	</script>
+</body>
+</html>


### PR DESCRIPTION
This is a WIP first pass at HTML tables. Right now, it supports `limit` and `offset` with pagination and selecting results per page.

There are still some features missing:
- [x] add or remove which columns are displayed (`select`)
- [x] sort by one or more columns, ascending or descending (`order`)
- [x] add where clauses (colname as query parameter)

I want to think about the best UI for each of these. I don't know how difficult it would be, but maybe we could have a little filter icon next to each column header which sorts kind of like an Excel sheet, but we need to show if it's asc/desc. I'm the most unsure about the best UI for adding in the where clauses, since we're using a specific grammar for these.