### PR TITLE
Add default limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ When running `sprocket` with no additional arguments, the base path (`/`) will n
 sprocket database.db -t tablename
 ```
 
+### Limits
+
+`sprocket` will show 100 results per page by default when you first view a table. This can always be changed using the HTML form or the `limit` query parameter, but if you wish to change the default you can do so with `-l`/`--limit`. For example, to always show 20 results when viewing a table:
+```bash
+sprocket database.db -l 20
+```
+
 ### CGI script
 
 You can also run `sprocket` as a CGI script using the `-c`/`--cgi` flag. For example, you can create a `sprocket.sh` script with the following content:

--- a/sprocket/resources/base.html
+++ b/sprocket/resources/base.html
@@ -32,6 +32,9 @@
 			white-space: pre-wrap;
 		}
 	</style>
+	{% if title %}
+	<title>{{ title }}</title>
+	{% endif %}
 </head>
 <body>
 	{% block content %}


### PR DESCRIPTION
Resolves #8 

I also noticed that some of the paths in the IEDB API were post-only paths and don't return a valid response on GET. I filtered these out from the list of tables.

---

### Limits

`sprocket` will show 100 results per page by default when you first view a table. This can always be changed using the HTML form or the `limit` query parameter, but if you wish to change the default you can do so with `-l`/`--limit`. For example, to always show 20 results when viewing a table:
```bash
sprocket database.db -l 20
```